### PR TITLE
Bflood/chain 166 - 2 phase settlement/withdrawals

### DIFF
--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -11,23 +11,31 @@ import {OwnableUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/a
 import {UUPSUpgradeable} from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {EIP712Upgradeable} from "openzeppelin-contracts-upgradeable/contracts/utils/cryptography/EIP712Upgradeable.sol";
 import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+import "forge-std/console.sol";
 
 contract Exchange is EIP712Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IExchange {
     mapping(address => mapping(address => uint256)) public balances;
-    mapping(address => uint256) public nativeBalances;
-    // this storage slot previously held the withdrawal nonces which have been removed. In order to maintain
-    // backward compatibility the slot is left unused. When adding a future variable this slot may be used
-    uint256 internal unused;
-
     uint256 public txProcessedCount;
     address public submitter;
     address public feeAccount;
     mapping(address => uint8) public tokenPrecision;
+    bytes32 public batchHash;
 
     string constant WITHDRAW_SIGNATURE = "Withdraw(address sender,address token,uint256 amount,uint64 nonce)";
     string constant WITHDRAW_NATIVE_SIGNATURE = "Withdraw(address sender,uint256 amount,uint64 nonce)";
     string constant ORDER_SIGNATURE =
         "Order(address sender,address baseToken,address quoteToken,int256 amount,uint256 price,int256 nonce)";
+
+    struct TokenBalance {
+        address sender;
+        address token;
+        uint256 balance;
+    }
+
+    struct SavedBalances {
+        uint32 count;
+        TokenBalance[] balances;
+    }
 
     function initialize(address _submitter, address _feeAccount, uint8 _nativePrecision) public initializer {
         __Ownable_init(msg.sender);
@@ -39,7 +47,7 @@ contract Exchange is EIP712Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IEx
     }
 
     receive() external payable {
-        nativeBalances[msg.sender] += msg.value;
+        balances[msg.sender][address(0)] += msg.value;
         emit Deposit(msg.sender, address(0), msg.value);
     }
 
@@ -71,26 +79,80 @@ contract Exchange is EIP712Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IEx
         emit Deposit(msg.sender, _token, _amount);
     }
 
-    function withdraw(address _token, uint256 _amount) external {
-        _withdraw(msg.sender, _token, _amount);
-    }
-
-    function withdraw(uint256 _amount) external {
-        _withdrawNative(msg.sender, _amount);
-    }
-
-    function submitTransactions(bytes[] calldata transactions) public onlySubmitter {
+    function submitBatch(bytes[] calldata transactions) public onlySubmitter {
+        require(batchHash != 0, "No batch prepared");
+        require(batchHash == _calculateBatchHash(transactions), "Hash does not match prepared batch");
         for (uint256 i = 0; i < transactions.length; i++) {
             bytes calldata transaction = transactions[i];
             processTransaction(transaction);
         }
         txProcessedCount += transactions.length;
+        batchHash = 0;
     }
 
     function processTransaction(bytes calldata transaction) internal {
         TransactionType txType = TransactionType(uint8(transaction[0]));
         if (txType == TransactionType.Withdraw) {
             WithdrawWithSignature memory signedTx = abi.decode(transaction[1:], (WithdrawWithSignature));
+            _withdraw(signedTx.tx.sender, signedTx.tx.token, signedTx.tx.amount);
+        } else if (txType == TransactionType.WithdrawNative) {
+            WithdrawNativeWithSignature memory signedTx = abi.decode(transaction[1:], (WithdrawNativeWithSignature));
+            _withdraw(signedTx.tx.sender, address(0), signedTx.tx.amount);
+        } else if (txType == TransactionType.SettleTrade) {
+            _settleTrade(abi.decode(transaction[1:], (SettleTrade)));
+        }
+    }
+
+    function prepareBatch(bytes[] calldata transactions) public onlySubmitter {
+        require(batchHash == 0, "Batch in progress, submit or rollback");
+        bool batchSucceeded = true;
+
+        // A single settlement changes 4 balances
+        SavedBalances memory savedBalances = SavedBalances(0, new TokenBalance[](transactions.length * 4));
+        for (uint256 i = 0; i < transactions.length; i++) {
+            bytes calldata transaction = transactions[i];
+            if (!prepareTransaction(transaction, savedBalances)) {
+                batchSucceeded = false;
+            }
+        }
+        // balances are restored in reverse order so we go back to original values
+        for (uint32 i = savedBalances.count; i > 0; i--) {
+            uint32 index = i - 1;
+            balances[savedBalances.balances[index].sender][savedBalances.balances[index].token] =
+                savedBalances.balances[index].balance;
+        }
+
+        if (batchSucceeded) {
+            batchHash = _calculateBatchHash(transactions);
+        }
+    }
+
+    function rollbackBatch() external onlySubmitter {
+        batchHash = 0;
+    }
+
+    modifier onlySubmitter() {
+        require(msg.sender == submitter, "Sender is not the submitter");
+        _;
+    }
+
+    function _calculateBatchHash(bytes[] calldata transactions) internal pure returns (bytes32) {
+        bytes memory buffer = new bytes(0);
+        for (uint256 i = 0; i < transactions.length; i++) {
+            bytes calldata transaction = transactions[i];
+            buffer = bytes.concat(buffer, transaction);
+        }
+        return keccak256(buffer);
+    }
+
+    function prepareTransaction(bytes calldata transaction, SavedBalances memory savedBalances)
+        internal
+        returns (bool)
+    {
+        TransactionType txType = TransactionType(uint8(transaction[0]));
+        if (txType == TransactionType.Withdraw) {
+            WithdrawWithSignature memory signedTx = abi.decode(transaction[1:], (WithdrawWithSignature));
+            _saveBalance(signedTx.tx.sender, signedTx.tx.token, savedBalances);
             bytes32 digest = _hashTypedDataV4(
                 keccak256(
                     abi.encode(
@@ -102,10 +164,13 @@ contract Exchange is EIP712Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IEx
                     )
                 )
             );
-            _validateSignature(signedTx.tx.sender, digest, signedTx.signature);
-            _withdraw(signedTx.tx.sender, signedTx.tx.token, signedTx.tx.amount);
+            if (!_validateSignature(signedTx.tx.sender, digest, signedTx.signature, signedTx.sequence)) {
+                return false;
+            }
+            return _withdrawDryRun(signedTx.tx.sender, signedTx.tx.token, signedTx.tx.amount, signedTx.sequence);
         } else if (txType == TransactionType.WithdrawNative) {
             WithdrawNativeWithSignature memory signedTx = abi.decode(transaction[1:], (WithdrawNativeWithSignature));
+            _saveBalance(signedTx.tx.sender, address(0), savedBalances);
             bytes32 digest = _hashTypedDataV4(
                 keccak256(
                     abi.encode(
@@ -116,21 +181,33 @@ contract Exchange is EIP712Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IEx
                     )
                 )
             );
-            _validateSignature(signedTx.tx.sender, digest, signedTx.signature);
-            _withdrawNative(signedTx.tx.sender, signedTx.tx.amount);
+            if (!_validateSignature(signedTx.tx.sender, digest, signedTx.signature, signedTx.sequence)) {
+                return false;
+            }
+            return _withdrawDryRun(signedTx.tx.sender, address(0), signedTx.tx.amount, signedTx.sequence);
         } else if (txType == TransactionType.SettleTrade) {
-            _settleTrade(abi.decode(transaction[1:], (SettleTrade)));
+            return _settleTradeDryRun(abi.decode(transaction[1:], (SettleTrade)), savedBalances);
+        } else {
+            require(false, "Unknown transaction");
+            return false;
         }
     }
 
-    modifier onlySubmitter() {
-        require(msg.sender == submitter, "Sender is not the submitter");
-        _;
+    function _saveBalance(address _sender, address _token, SavedBalances memory savedBalances) internal view {
+        savedBalances.balances[savedBalances.count] = TokenBalance(_sender, _token, balances[_sender][_token]);
+        savedBalances.count += 1;
     }
 
-    function _validateSignature(address _sender, bytes32 _digest, bytes memory _signature) internal view virtual {
+    function _validateSignature(address _sender, bytes32 _digest, bytes memory _signature, uint64 sequence)
+        internal
+        returns (bool)
+    {
         address recovered = ECDSA.recover(_digest, _signature);
-        require(recovered == _sender, "Invalid Signature");
+        if (recovered != _sender) {
+            emit PrepareTransactionFailed(sequence, ErrorCode.InvalidSignature);
+            return false;
+        }
+        return true;
     }
 
     function _validateOrder(address _baseToken, address _quoteToken, OrderWithSignature memory _order)
@@ -155,66 +232,114 @@ contract Exchange is EIP712Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IEx
         return digest;
     }
 
+    function _withdrawDryRun(address _sender, address _token, uint256 _amount, uint64 sequence)
+        internal
+        returns (bool)
+    {
+        uint256 balance = balances[_sender][_token];
+        if (_amount == 0) {
+            _amount = balance;
+        }
+        return _adjustBalanceDryRun(_sender, _token, -int256(_amount), sequence, true);
+    }
+
     function _withdraw(address _sender, address _token, uint256 _amount) internal {
         uint256 balance = balances[_sender][_token];
         if (_amount == 0) {
             _amount = balance;
         }
-        uint256 _actual = uint256(-_adjustBalance(_sender, _token, -int256(_amount)));
+        uint256 _actual = uint256(-_adjustBalance(_sender, _token, -int256(_amount), true));
 
-        IERC20 erc20 = IERC20(_token);
-        erc20.transfer(_sender, _actual);
+        if (_token == address(0)) {
+            payable(_sender).transfer(_actual);
+        } else {
+            IERC20 erc20 = IERC20(_token);
+            erc20.transfer(_sender, _actual);
+        }
 
         emit Withdrawal(_sender, _token, _actual);
     }
 
-    function _withdrawNative(address _sender, uint256 _amount) internal {
-        uint256 balance = nativeBalances[_sender];
-        if (_amount == 0) {
-            _amount = balance;
-        }
-        uint256 _actual = uint256(-_adjustNativeBalance(_sender, -int256(_amount)));
-        payable(_sender).transfer(_actual);
+    function _settleTradeDryRun(SettleTrade memory _trade, SavedBalances memory savedBalances)
+        internal
+        returns (bool)
+    {
+        //
+        // trade.amount is positive if taker is buying and negative if selling
+        // fee amounts are passed in (can be 0) and are taken in the quote currency from taker and maker.
+        //
+        int256 baseAdjustment = _trade.amount;
+        int256 notional = (_trade.amount * int256(_trade.price)) / int256(10 ** _tokenPrecision(_trade.baseToken));
+        int256 takerQuoteAdjustment = -notional - int256(_trade.takerFee);
+        int256 makerQuoteAdjustment = notional - int256(_trade.makerFee);
 
-        emit Withdrawal(_sender, address(0), _actual);
+        _saveBalance(_trade.takerOrder.tx.sender, _trade.baseToken, savedBalances);
+        _saveBalance(_trade.makerOrder.tx.sender, _trade.baseToken, savedBalances);
+        _saveBalance(_trade.takerOrder.tx.sender, _trade.quoteToken, savedBalances);
+        _saveBalance(_trade.makerOrder.tx.sender, _trade.quoteToken, savedBalances);
+
+        return _adjustBalanceDryRun(
+            _trade.takerOrder.tx.sender, _trade.baseToken, baseAdjustment, _trade.sequence, false
+        )
+            && _adjustBalanceDryRun(_trade.makerOrder.tx.sender, _trade.baseToken, -baseAdjustment, _trade.sequence, false)
+            && _adjustBalanceDryRun(
+                _trade.takerOrder.tx.sender, _trade.quoteToken, takerQuoteAdjustment, _trade.sequence, false
+            )
+            && _adjustBalanceDryRun(
+                _trade.makerOrder.tx.sender, _trade.quoteToken, makerQuoteAdjustment, _trade.sequence, false
+            );
     }
 
-    function _adjustBalance(address _sender, address _token, int256 _amount) internal returns (int256) {
-        if (_token == address(0)) {
-            return _adjustNativeBalance(_sender, _amount);
+    function _adjustBalanceDryRun(
+        address _sender,
+        address _token,
+        int256 _amount,
+        uint64 sequence,
+        bool _allowAboveBalance
+    ) internal returns (bool) {
+        if (_amount < 0) {
+            uint256 balance = balances[_sender][_token];
+            uint256 amount = uint256(-_amount);
+            if (amount > balance) {
+                if (_allowAboveBalance) {
+                    emit AmountAdjusted(_sender, _token, amount, balance);
+                    balances[_sender][_token] -= balance;
+                    return true;
+                } else {
+                    emit PrepareTransactionFailed(sequence, ErrorCode.InsufficientBalance);
+                    return false;
+                }
+            } else {
+                balances[_sender][_token] -= amount;
+                return true;
+            }
         } else {
-            if (_amount < 0) {
-                uint256 balance = balances[_sender][_token];
-                uint256 amount = uint256(-_amount);
-                if (amount > balance) {
+            balances[_sender][_token] += uint256(_amount);
+            return true;
+        }
+    }
+
+    function _adjustBalance(address _sender, address _token, int256 _amount, bool _allowAboveBalance)
+        internal
+        returns (int256)
+    {
+        if (_amount < 0) {
+            uint256 balance = balances[_sender][_token];
+            uint256 amount = uint256(-_amount);
+            if (amount > balance) {
+                if (_allowAboveBalance) {
                     emit AmountAdjusted(_sender, _token, amount, balance);
                     balances[_sender][_token] -= balance;
                     return -int256(balance);
                 } else {
-                    balances[_sender][_token] -= amount;
-                    return _amount;
+                    revert("Insufficient balance");
                 }
             } else {
-                balances[_sender][_token] += uint256(_amount);
-                return _amount;
-            }
-        }
-    }
-
-    function _adjustNativeBalance(address _sender, int256 _amount) internal returns (int256) {
-        if (_amount < 0) {
-            uint256 balance = nativeBalances[_sender];
-            uint256 amount = uint256(-_amount);
-            if (amount > balance) {
-                emit AmountAdjusted(_sender, address(0), amount, balance);
-                nativeBalances[_sender] -= balance;
-                return -int256(balance);
-            } else {
-                nativeBalances[_sender] -= amount;
+                balances[_sender][_token] -= amount;
                 return _amount;
             }
         } else {
-            nativeBalances[_sender] += uint256(_amount);
+            balances[_sender][_token] += uint256(_amount);
             return _amount;
         }
     }
@@ -230,17 +355,17 @@ contract Exchange is EIP712Upgradeable, UUPSUpgradeable, OwnableUpgradeable, IEx
         //
         int256 baseAdjustment = _trade.amount;
         int256 notional = (_trade.amount * int256(_trade.price)) / int256(10 ** _tokenPrecision(_trade.baseToken));
-        _adjustBalance(_trade.takerOrder.tx.sender, _trade.baseToken, baseAdjustment);
-        _adjustBalance(_trade.makerOrder.tx.sender, _trade.baseToken, -baseAdjustment);
+        _adjustBalance(_trade.takerOrder.tx.sender, _trade.baseToken, baseAdjustment, false);
+        _adjustBalance(_trade.makerOrder.tx.sender, _trade.baseToken, -baseAdjustment, false);
 
         int256 takerQuoteAdjustment = -notional - int256(_trade.takerFee);
         int256 makerQuoteAdjustment = notional - int256(_trade.makerFee);
-        _adjustBalance(_trade.takerOrder.tx.sender, _trade.quoteToken, takerQuoteAdjustment);
-        _adjustBalance(_trade.makerOrder.tx.sender, _trade.quoteToken, makerQuoteAdjustment);
+        _adjustBalance(_trade.takerOrder.tx.sender, _trade.quoteToken, takerQuoteAdjustment, false);
+        _adjustBalance(_trade.makerOrder.tx.sender, _trade.quoteToken, makerQuoteAdjustment, false);
 
         // fees go to a fee account
         if (_trade.takerFee + _trade.makerFee > 0) {
-            _adjustBalance(feeAccount, _trade.quoteToken, int256(_trade.takerFee + _trade.makerFee));
+            _adjustBalance(feeAccount, _trade.quoteToken, int256(_trade.takerFee + _trade.makerFee), false);
         }
 
         // we emit an order filled event for both the taker and maker orders. This includes the original order and

--- a/src/interfaces/IExchange.sol
+++ b/src/interfaces/IExchange.sol
@@ -13,6 +13,11 @@ interface IExchange is IVersion {
         SettleTrade
     }
 
+    enum ErrorCode {
+        InvalidSignature,
+        InsufficientBalance
+    }
+
     struct Withdraw {
         address sender;
         address token;
@@ -21,6 +26,7 @@ interface IExchange is IVersion {
     }
 
     struct WithdrawWithSignature {
+        uint64 sequence;
         Withdraw tx;
         bytes signature;
     }
@@ -32,6 +38,7 @@ interface IExchange is IVersion {
     }
 
     struct WithdrawNativeWithSignature {
+        uint64 sequence;
         WithdrawNative tx;
         bytes signature;
     }
@@ -49,6 +56,7 @@ interface IExchange is IVersion {
     }
 
     struct SettleTrade {
+        uint64 sequence;
         address baseToken;
         address quoteToken;
         int256 amount;
@@ -77,6 +85,8 @@ interface IExchange is IVersion {
         ExecutionInfo executionInfo
     );
 
+    event PrepareTransactionFailed(uint64 sequence, ErrorCode errorCode);
+
     event AmountAdjusted(address indexed sender, address token, uint256 requested, uint256 actual);
 
     function DOMAIN_SEPARATOR() external view returns (bytes32);
@@ -85,11 +95,11 @@ interface IExchange is IVersion {
 
     receive() external payable;
 
-    function withdraw(address _token, uint256 _amount) external;
+    function submitBatch(bytes[] calldata transactions) external;
 
-    function withdraw(uint256 _amount) external;
+    function prepareBatch(bytes[] calldata transactions) external;
 
-    function submitTransactions(bytes[] calldata transactions) external;
+    function rollbackBatch() external;
 
     function setSubmitter(address _submitter) external;
 

--- a/test/Exchange.t.sol
+++ b/test/Exchange.t.sol
@@ -11,11 +11,6 @@ import "./contracts/ExchangeUpgrade.sol";
 import "./ExchangeBaseTest.sol";
 
 contract ExchangeTest is ExchangeBaseTest {
-    uint256 internal wallet1PrivateKey = 0x12345678;
-    uint256 internal wallet2PrivateKey = 0x123456789;
-    address internal wallet1 = vm.addr(wallet1PrivateKey);
-    address internal wallet2 = vm.addr(wallet2PrivateKey);
-
     function setUp() public override {
         super.setUp();
         vm.deal(wallet1, 10 ether);
@@ -23,21 +18,21 @@ contract ExchangeTest is ExchangeBaseTest {
     }
 
     function test_ERC20Deposit() public {
-        (address usdcAddress, address btcAddress) = setupWallets();
+        setupWallets();
 
         deposit(wallet1, usdcAddress, 1000e6);
-        verifyBalances(wallet1, usdcAddress, 1000e6, 4000e6, 1000e6);
+        verifyBalances(wallet1, usdcAddress, 1000e6, 499000e6, 1000e6);
         deposit(wallet1, btcAddress, 55e8);
         verifyBalances(wallet1, btcAddress, 55e8, 45e8, 55e8);
     }
 
     function test_MultipleERC20Deposits() public {
-        (address usdcAddress, address btcAddress) = setupWallets();
+        setupWallets();
 
         deposit(wallet1, usdcAddress, 1000e6);
-        verifyBalances(wallet1, usdcAddress, 1000e6, 4000e6, 1000e6);
+        verifyBalances(wallet1, usdcAddress, 1000e6, 499000e6, 1000e6);
         deposit(wallet1, usdcAddress, 300e6);
-        verifyBalances(wallet1, usdcAddress, 1300e6, 3700e6, 1300e6);
+        verifyBalances(wallet1, usdcAddress, 1300e6, 498700e6, 1300e6);
 
         deposit(wallet1, btcAddress, 55e8);
         verifyBalances(wallet1, btcAddress, 55e8, 45e8, 55e8);
@@ -46,43 +41,43 @@ contract ExchangeTest is ExchangeBaseTest {
     }
 
     function test_ERC20Withdrawal() public {
-        (address usdcAddress, address btcAddress) = setupWallets();
+        setupWallets();
 
         deposit(wallet1, usdcAddress, 1000e6);
-        verifyBalances(wallet1, usdcAddress, 1000e6, 4000e6, 1000e6);
-        withdraw(wallet1, usdcAddress, 133e6, 133e6);
-        verifyBalances(wallet1, usdcAddress, 867e6, 4133e6, 867e6);
+        verifyBalances(wallet1, usdcAddress, 1000e6, 499000e6, 1000e6);
+        withdraw(wallet1PrivateKey, usdcAddress, 133e6, 133e6);
+        verifyBalances(wallet1, usdcAddress, 867e6, 499133e6, 867e6);
 
         deposit(wallet1, btcAddress, 55e8);
         verifyBalances(wallet1, btcAddress, 55e8, 45e8, 55e8);
-        withdraw(wallet1, btcAddress, 4e8, 4e8);
+        withdraw(wallet1PrivateKey, btcAddress, 4e8, 4e8);
         verifyBalances(wallet1, btcAddress, 51e8, 49e8, 51e8);
 
-        withdraw(wallet1, btcAddress, 0, 51e8);
+        withdraw(wallet1PrivateKey, btcAddress, 0, 51e8);
         verifyBalances(wallet1, btcAddress, 0, 100e8, 0);
     }
 
     function test_MultipleWallets() public {
-        (address usdcAddress,) = setupWallets();
+        setupWallets();
 
         deposit(wallet1, usdcAddress, 1000e6);
-        verifyBalances(wallet1, usdcAddress, 1000e6, 4000e6, 1000e6);
+        verifyBalances(wallet1, usdcAddress, 1000e6, 499000e6, 1000e6);
         deposit(wallet2, usdcAddress, 800e6);
-        verifyBalances(wallet2, usdcAddress, 800e6, 4200e6, 1800e6);
+        verifyBalances(wallet2, usdcAddress, 800e6, 499200e6, 1800e6);
 
-        withdraw(wallet1, usdcAddress, 133e6, 133e6);
-        verifyBalances(wallet1, usdcAddress, 867e6, 4133e6, 1667e6);
-        withdraw(wallet2, usdcAddress, 120e6, 120e6);
-        verifyBalances(wallet2, usdcAddress, 680e6, 4320e6, 1547e6);
+        withdraw(wallet1PrivateKey, usdcAddress, 133e6, 133e6);
+        verifyBalances(wallet1, usdcAddress, 867e6, 499133e6, 1667e6);
+        withdraw(wallet2PrivateKey, usdcAddress, 120e6, 120e6);
+        verifyBalances(wallet2, usdcAddress, 680e6, 499320e6, 1547e6);
     }
 
     function test_Upgrade() public {
-        (address usdcAddress,) = setupWallets();
+        setupWallets();
 
         deposit(wallet1, usdcAddress, 1000e6);
-        verifyBalances(wallet1, usdcAddress, 1000e6, 4000e6, 1000e6);
+        verifyBalances(wallet1, usdcAddress, 1000e6, 499000e6, 1000e6);
         deposit(wallet2, usdcAddress, 800e6);
-        verifyBalances(wallet2, usdcAddress, 800e6, 4200e6, 1800e6);
+        verifyBalances(wallet2, usdcAddress, 800e6, 499200e6, 1800e6);
 
         // test that only the owner can upgrade the contract
         vm.startPrank(wallet1);
@@ -105,52 +100,42 @@ contract ExchangeTest is ExchangeBaseTest {
         assertEq(ExchangeUpgrade(exchangeProxyAddress).value(), 1000);
 
         // check balances are maintained after the upgrade
-        verifyBalances(wallet1, usdcAddress, 1000e6, 4000e6, 1800e6);
-        verifyBalances(wallet2, usdcAddress, 800e6, 4200e6, 1800e6);
+        verifyBalances(wallet1, usdcAddress, 1000e6, 499000e6, 1800e6);
+        verifyBalances(wallet2, usdcAddress, 800e6, 499200e6, 1800e6);
 
         // perform some withdrawals
-        withdraw(wallet1, usdcAddress, 100e6, 100e6);
-        verifyBalances(wallet1, usdcAddress, 900e6, 4100e6, 1700e6);
-        withdraw(wallet2, usdcAddress, 120e6, 120e6);
-        verifyBalances(wallet2, usdcAddress, 680e6, 4320e6, 1580e6);
+        withdraw(wallet1PrivateKey, usdcAddress, 100e6, 100e6);
+        verifyBalances(wallet1, usdcAddress, 900e6, 499100e6, 1700e6);
+        withdraw(wallet2PrivateKey, usdcAddress, 120e6, 120e6);
+        verifyBalances(wallet2, usdcAddress, 680e6, 499320e6, 1580e6);
     }
 
-    function test_NativeDepositsAndWithdrawals() public {
+    function test_NativeDeposits() public {
         deposit(wallet1, 2e18);
         verifyBalances(wallet1, 2e18, 8e18, 2e18);
 
         deposit(wallet2, 3e18);
         verifyBalances(wallet2, 3e18, 7e18, 5e18);
-
-        withdraw(wallet1, 1e18, 1e18);
-        verifyBalances(wallet1, 1e18, 9e18, 4e18);
-
-        withdraw(wallet2, 1e18, 1e18);
-        verifyBalances(wallet2, 2e18, 8e18, 3e18);
-
-        // test withdrawal all
-        withdraw(wallet2, 0e18, 2e18);
-        verifyBalances(wallet2, 0e18, 10e18, 1e18);
     }
 
     function test_EIP712Withdrawals() public {
-        (address usdcAddress,) = setupWallets();
+        setupWallets();
 
         // wallet1 - deposit usdc and native token
         deposit(wallet1, usdcAddress, 1000e6);
-        verifyBalances(wallet1, usdcAddress, 1000e6, 4000e6, 1000e6);
+        verifyBalances(wallet1, usdcAddress, 1000e6, 499000e6, 1000e6);
         deposit(wallet1, 2e18);
         verifyBalances(wallet1, 2e18, 8e18, 2e18);
 
         // wallet2 - deposit USDC
         deposit(wallet2, usdcAddress, 1000e6);
-        verifyBalances(wallet1, usdcAddress, 1000e6, 4000e6, 2000e6);
+        verifyBalances(wallet1, usdcAddress, 1000e6, 499000e6, 2000e6);
 
         uint64 wallet1Nonce = 1000;
-        bytes memory tx1 = createSignedWithdrawTx(wallet1PrivateKey, usdcAddress, 200e6, wallet1Nonce);
-        bytes memory tx2 = createSignedWithdrawNativeTx(wallet1PrivateKey, 1e18, wallet1Nonce + 200);
+        bytes memory tx1 = createSignedWithdrawTx(wallet1PrivateKey, usdcAddress, 200e6, wallet1Nonce, 1);
+        bytes memory tx2 = createSignedWithdrawNativeTx(wallet1PrivateKey, 1e18, wallet1Nonce + 200, 2);
         uint64 wallet2Nonce = 10000;
-        bytes memory tx3 = createSignedWithdrawTx(wallet2PrivateKey, usdcAddress, 300e6, wallet2Nonce);
+        bytes memory tx3 = createSignedWithdrawTx(wallet2PrivateKey, usdcAddress, 300e6, wallet2Nonce, 3);
 
         uint256 txProcessedCount = exchange.txProcessedCount();
 
@@ -158,55 +143,48 @@ contract ExchangeTest is ExchangeBaseTest {
         txs[0] = tx1;
         txs[1] = tx2;
         txs[2] = tx3;
+
+        vm.prank(submitter);
+        exchange.prepareBatch(txs);
+
         vm.expectEmit(exchangeProxyAddress);
         emit IExchange.Withdrawal(wallet1, usdcAddress, 200e6);
         emit IExchange.Withdrawal(wallet1, address(0), 1e18);
         emit IExchange.Withdrawal(wallet2, usdcAddress, 300e6);
         vm.prank(submitter);
-        exchange.submitTransactions(txs);
+        exchange.submitBatch(txs);
 
         // verify balances
-        verifyBalances(wallet1, usdcAddress, 800e6, 4200e6, 1500e6);
+        verifyBalances(wallet1, usdcAddress, 800e6, 499200e6, 1500e6);
         verifyBalances(wallet1, 1e18, 9e18, 1e18);
-        verifyBalances(wallet2, usdcAddress, 700e6, 4300e6, 1500e6);
+        verifyBalances(wallet2, usdcAddress, 700e6, 499300e6, 1500e6);
 
         assertEq(txProcessedCount + 3, exchange.txProcessedCount());
     }
 
     function test_AmountAdjustment() public {
-        (address usdcAddress,) = setupWallets();
+        setupWallets();
         deposit(wallet1, usdcAddress, 1000e6);
-        vm.expectEmit(exchangeProxyAddress);
-        emit IExchange.AmountAdjusted(wallet1, usdcAddress, 1001e6, 1000e6);
-        vm.expectEmit(exchangeProxyAddress);
-        emit IExchange.Withdrawal(wallet1, usdcAddress, 1000e6);
-        vm.startPrank(wallet1);
-        exchange.withdraw(usdcAddress, 1001e6);
+        withdraw(wallet1PrivateKey, usdcAddress, 1001e6, 1000e6);
         vm.stopPrank();
 
         deposit(wallet1, 2e18);
-        vm.expectEmit(exchangeProxyAddress);
-        emit IExchange.AmountAdjusted(wallet1, address(0), 3e18, 2e18);
-        vm.expectEmit(exchangeProxyAddress);
-        emit IExchange.Withdrawal(wallet1, address(0), 2e18);
-        vm.startPrank(wallet1);
-        exchange.withdraw(3e18);
-        vm.stopPrank();
+        withdraw(wallet1PrivateKey, address(0), 3e18, 2e18);
         verifyBalances(wallet1, 0, 10e18, 0);
     }
 
     function test_EIP712ErrorCases() public {
-        (address usdcAddress,) = setupWallets();
+        setupWallets();
 
         // wallet1 - deposit usdc and native token
         deposit(wallet1, usdcAddress, 1000e6);
-        verifyBalances(wallet1, usdcAddress, 1000e6, 4000e6, 1000e6);
+        verifyBalances(wallet1, usdcAddress, 1000e6, 499000e6, 1000e6);
         deposit(wallet1, 2e18);
         verifyBalances(wallet1, 2e18, 8e18, 2e18);
 
         uint64 wallet1Nonce = 22222;
-        bytes memory tx1 = createSignedWithdrawTx(wallet1PrivateKey, usdcAddress, 200e6, wallet1Nonce);
-        bytes memory tx2 = createSignedWithdrawNativeTx(wallet1PrivateKey, 3e18, wallet1Nonce + 1); // insufficient balance
+        bytes memory tx1 = createSignedWithdrawTx(wallet1PrivateKey, usdcAddress, 200e6, wallet1Nonce, 1);
+        bytes memory tx2 = createSignedWithdrawNativeTx(wallet1PrivateKey, 3e18, wallet1Nonce + 1, 2); // insufficient balance
         uint256 txProcessedCount = exchange.txProcessedCount();
 
         bytes[] memory txs = new bytes[](2);
@@ -216,7 +194,7 @@ contract ExchangeTest is ExchangeBaseTest {
         // check fails if not the submitter
         vm.prank(wallet1);
         vm.expectRevert(bytes("Sender is not the submitter"));
-        exchange.submitTransactions(txs);
+        exchange.prepareBatch(txs);
 
         // must be a valid address
         vm.expectRevert(bytes("Not a valid address"));
@@ -237,64 +215,22 @@ contract ExchangeTest is ExchangeBaseTest {
         // should fail with old submitter
         vm.prank(submitter);
         vm.expectRevert(bytes("Sender is not the submitter"));
-        exchange.submitTransactions(txs);
+        exchange.submitBatch(txs);
 
         // check balance adjusted by remaining amounting if too much requested and amount adjusted events emitted
         txs[1] = tx2;
-        vm.prank(newSubmitter);
+        vm.startPrank(newSubmitter);
+        exchange.prepareBatch(txs);
         vm.expectEmit(exchangeProxyAddress);
         emit IExchange.AmountAdjusted(wallet1, address(0), 3e18, 2e18);
         vm.expectEmit(exchangeProxyAddress);
         emit IExchange.Withdrawal(wallet1, address(0), 2e18);
-        exchange.submitTransactions(txs);
+        exchange.submitBatch(txs);
+        vm.stopPrank();
 
         assertEq(txProcessedCount + 2, exchange.txProcessedCount());
 
         // set it back
         exchange.setSubmitter(submitter);
-    }
-
-    function createSignedWithdrawTx(uint256 walletPrivateKey, address tokenAddress, uint256 amount, uint64 nonce)
-        internal
-        view
-        returns (bytes memory)
-    {
-        IExchange.Withdraw memory _withdraw =
-            IExchange.Withdraw({sender: vm.addr(walletPrivateKey), token: tokenAddress, amount: amount, nonce: nonce});
-
-        bytes32 digest = SigUtils.getTypedDataHash(exchange.DOMAIN_SEPARATOR(), SigUtils.getStructHash(_withdraw));
-
-        bytes memory signature = sign(walletPrivateKey, digest);
-        return packTx(
-            IExchange.TransactionType.Withdraw,
-            abi.encode(_withdraw.sender, _withdraw.token, _withdraw.amount, _withdraw.nonce, signature)
-        );
-    }
-
-    function createSignedWithdrawNativeTx(uint256 walletPrivateKey, uint256 amount, uint64 nonce)
-        internal
-        view
-        returns (bytes memory)
-    {
-        IExchange.WithdrawNative memory _withdraw =
-            IExchange.WithdrawNative({sender: vm.addr(walletPrivateKey), amount: amount, nonce: nonce});
-
-        bytes32 digest = SigUtils.getTypedDataHash(exchange.DOMAIN_SEPARATOR(), SigUtils.getStructHash(_withdraw));
-
-        bytes memory signature = sign(walletPrivateKey, digest);
-        return packTx(
-            IExchange.TransactionType.WithdrawNative,
-            abi.encode(_withdraw.sender, _withdraw.amount, _withdraw.nonce, signature)
-        );
-    }
-
-    function setupWallets() internal returns (address, address) {
-        MockERC20 usdcMock = new MockERC20("USD Coin", "USDC", 6);
-        usdcMock.mint(wallet1, 5000e6);
-        usdcMock.mint(wallet2, 5000e6);
-        MockERC20 btcMock = new MockERC20("Bitcoin", "BTC", 8);
-        btcMock.mint(wallet1, 100e8);
-        btcMock.mint(wallet2, 100e8);
-        return (address(usdcMock), address(btcMock));
     }
 }

--- a/test/TradeExecution.t.sol
+++ b/test/TradeExecution.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 
 import {Test, console} from "forge-std/Test.sol";
-import {MockERC20} from "./contracts/MockERC20.sol";
 import {Exchange} from "../src/Exchange.sol";
 import {IExchange} from "../src/interfaces/IExchange.sol";
 import {ERC1967Utils} from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Utils.sol";
@@ -10,12 +9,10 @@ import "./utils/SigUtils.sol";
 import {ExchangeBaseTest} from "./ExchangeBaseTest.sol";
 
 contract TradeExecutionTest is ExchangeBaseTest {
-    uint256 internal takerPrivateKey = 0x12345678;
-    uint256 internal makerPrivateKey = 0x123456789;
+    uint256 internal takerPrivateKey = wallet1PrivateKey;
+    uint256 internal makerPrivateKey = wallet2PrivateKey;
     address internal taker = vm.addr(takerPrivateKey);
     address internal maker = vm.addr(makerPrivateKey);
-    address internal usdcAddress;
-    address internal btcAddress;
 
     function setUp() public override {
         super.setUp();
@@ -40,11 +37,12 @@ contract TradeExecutionTest is ExchangeBaseTest {
         (IExchange.OrderWithSignature memory makerOrder, bytes32 makerOrderDigest) =
             signOrder(makerPrivateKey, btcAddress, usdcAddress, -2e8, 70000e6, 2);
         bytes memory tx1 =
-            createTradeExecution(btcAddress, usdcAddress, 2e8, 70000e6, 100e6, 20e6, takerOrder, makerOrder);
+            createTradeExecution(btcAddress, usdcAddress, 2e8, 70000e6, 100e6, 20e6, takerOrder, makerOrder, 100);
 
         bytes[] memory txs = new bytes[](1);
         txs[0] = tx1;
-        vm.prank(submitter);
+        vm.startPrank(submitter);
+        exchange.prepareBatch(txs);
         vm.expectEmit(exchangeProxyAddress);
         emit IExchange.OrderFilled(
             takerOrderDigest,
@@ -77,7 +75,8 @@ contract TradeExecutionTest is ExchangeBaseTest {
                 quoteAdjustment: 140000e6 - 20e6
             })
         );
-        exchange.submitTransactions(txs);
+        exchange.submitBatch(txs);
+        vm.stopPrank();
 
         verifyBalances(taker, btcAddress, 2e8, 100e8, 55e8);
         verifyBalances(maker, btcAddress, 55e8 - 2e8, 45e8, 55e8);
@@ -103,10 +102,12 @@ contract TradeExecutionTest is ExchangeBaseTest {
         (IExchange.OrderWithSignature memory makerOrder, bytes32 makerOrderDigest) =
             signOrder(makerPrivateKey, btcAddress, usdcAddress, 5e8, 70000e6, 2);
         bytes memory tx1 =
-            createTradeExecution(btcAddress, usdcAddress, -2e8, 70000e6, 100e6, 20e6, takerOrder, makerOrder);
+            createTradeExecution(btcAddress, usdcAddress, -2e8, 70000e6, 100e6, 20e6, takerOrder, makerOrder, 1000);
 
         bytes[] memory txs = new bytes[](1);
         txs[0] = tx1;
+        vm.startPrank(submitter);
+        exchange.prepareBatch(txs);
         vm.expectEmit(exchangeProxyAddress);
         emit IExchange.OrderFilled(
             takerOrderDigest,
@@ -139,8 +140,8 @@ contract TradeExecutionTest is ExchangeBaseTest {
                 quoteAdjustment: -(140000e6 + 20e6)
             })
         );
-        vm.prank(submitter);
-        exchange.submitTransactions(txs);
+        exchange.submitBatch(txs);
+        vm.stopPrank();
 
         verifyBalances(taker, btcAddress, 3e8, 95e8, 5e8);
         verifyBalances(maker, btcAddress, 2e8, 100e8, 5e8);
@@ -164,11 +165,13 @@ contract TradeExecutionTest is ExchangeBaseTest {
             signOrder(takerPrivateKey, btcAddress, address(0), 1e7, 20e18, 1);
         (IExchange.OrderWithSignature memory makerOrder, bytes32 makerOrderDigest) =
             signOrder(makerPrivateKey, btcAddress, address(0), 2e8, 20e18, 2);
-        bytes memory tx1 = createTradeExecution(btcAddress, address(0), 1e7, 20e18, 2e16, 1e16, takerOrder, makerOrder);
+        bytes memory tx1 =
+            createTradeExecution(btcAddress, address(0), 1e7, 20e18, 2e16, 1e16, takerOrder, makerOrder, 1000);
 
         bytes[] memory txs = new bytes[](1);
         txs[0] = tx1;
-        vm.prank(submitter);
+        vm.startPrank(submitter);
+        exchange.prepareBatch(txs);
         vm.expectEmit(exchangeProxyAddress);
         emit IExchange.OrderFilled(
             takerOrderDigest,
@@ -201,7 +204,8 @@ contract TradeExecutionTest is ExchangeBaseTest {
                 quoteAdjustment: 2e18 - 1e16
             })
         );
-        exchange.submitTransactions(txs);
+        exchange.submitBatch(txs);
+        vm.stopPrank();
 
         verifyBalances(taker, btcAddress, 1e7, 100e8, 2e8);
         verifyBalances(taker, 3e18 - 2e18 - 2e16, 7e18, 3e18);
@@ -229,13 +233,15 @@ contract TradeExecutionTest is ExchangeBaseTest {
         (IExchange.OrderWithSignature memory makerOrder2, bytes32 makerOrderDigest2) =
             signOrder(makerPrivateKey, btcAddress, usdcAddress, 14e7, 70000e6, 3);
         bytes memory tx1 =
-            createTradeExecution(btcAddress, usdcAddress, -6e7, 70000e6, 40e6, 10e6, takerOrder, makerOrder1);
+            createTradeExecution(btcAddress, usdcAddress, -6e7, 70000e6, 40e6, 10e6, takerOrder, makerOrder1, 1000);
         bytes memory tx2 =
-            createTradeExecution(btcAddress, usdcAddress, -14e7, 70000e6, 60e6, 10e6, takerOrder, makerOrder2);
+            createTradeExecution(btcAddress, usdcAddress, -14e7, 70000e6, 60e6, 10e6, takerOrder, makerOrder2, 1001);
 
         bytes[] memory txs = new bytes[](2);
         txs[0] = tx1;
         txs[1] = tx2;
+        vm.startPrank(submitter);
+        exchange.prepareBatch(txs);
         vm.expectEmit(exchangeProxyAddress);
         emit IExchange.OrderFilled(
             takerOrderDigest,
@@ -300,8 +306,8 @@ contract TradeExecutionTest is ExchangeBaseTest {
                 quoteAdjustment: -(98000e6 + 10e6)
             })
         );
-        vm.prank(submitter);
-        exchange.submitTransactions(txs);
+        exchange.submitBatch(txs);
+        vm.stopPrank();
 
         verifyBalances(taker, btcAddress, 3e8, 95e8, 5e8);
         verifyBalances(maker, btcAddress, 2e8, 100e8, 5e8);
@@ -326,16 +332,16 @@ contract TradeExecutionTest is ExchangeBaseTest {
                 signOrder(takerPrivateKey, btcAddress, usdcAddress, 3e8, 70000e6, 1);
             (IExchange.OrderWithSignature memory makerOrder,) =
                 signOrder(makerPrivateKey, btcAddress, usdcAddress, -5e8, 70000e6, 2);
-            bytes memory tx1 = createTradeExecution(btcAddress, address(0), 3e8, 70000e6, 0, 0, takerOrder, makerOrder);
+            bytes memory tx1 =
+                createTradeExecution(btcAddress, address(0), 3e8, 70000e6, 0, 0, takerOrder, makerOrder, 1000);
 
             bytes[] memory txs = new bytes[](1);
             txs[0] = tx1;
-            vm.prank(submitter);
+            vm.startPrank(submitter);
             vm.expectEmit(exchangeProxyAddress);
-            emit IExchange.AmountAdjusted(maker, btcAddress, 3e8, 0);
-            vm.expectEmit(exchangeProxyAddress);
-            emit IExchange.AmountAdjusted(taker, address(0), 210000e6, 0);
-            exchange.submitTransactions(txs);
+            emit IExchange.PrepareTransactionFailed(1000, IExchange.ErrorCode.InsufficientBalance);
+            exchange.prepareBatch(txs);
+            vm.stopPrank();
         }
 
         {
@@ -344,14 +350,16 @@ contract TradeExecutionTest is ExchangeBaseTest {
                 signOrder(takerPrivateKey, btcAddress, usdcAddress, -6e8, 70000e6, 1);
             (IExchange.OrderWithSignature memory makerOrder,) =
                 signOrder(makerPrivateKey, btcAddress, usdcAddress, 8e8, 70000e6, 2);
-            bytes memory tx1 = createTradeExecution(btcAddress, address(0), -6e8, 70000e6, 0, 0, takerOrder, makerOrder);
+            bytes memory tx1 =
+                createTradeExecution(btcAddress, address(0), -6e8, 70000e6, 0, 0, takerOrder, makerOrder, 1000);
 
             bytes[] memory txs = new bytes[](1);
             txs[0] = tx1;
-            vm.prank(submitter);
+            vm.startPrank(submitter);
             vm.expectEmit(exchangeProxyAddress);
-            emit IExchange.AmountAdjusted(maker, address(0), 420000e6, 210000e6);
-            exchange.submitTransactions(txs);
+            emit IExchange.PrepareTransactionFailed(1000, IExchange.ErrorCode.InsufficientBalance);
+            exchange.prepareBatch(txs);
+            vm.stopPrank();
         }
     }
 
@@ -378,14 +386,15 @@ contract TradeExecutionTest is ExchangeBaseTest {
         uint256 takerFee,
         uint256 makerFee,
         IExchange.OrderWithSignature memory takerOrder,
-        IExchange.OrderWithSignature memory makerOrder
+        IExchange.OrderWithSignature memory makerOrder,
+        uint256 sequence
     ) internal pure returns (bytes memory) {
         return packTx(
             IExchange.TransactionType.SettleTrade,
             abi.encodePacked(
-                abi.encode(baseToken, quoteToken, amount, price, takerFee, makerFee),
-                uint256(0x100),
-                uint256(0x220),
+                abi.encode(sequence, baseToken, quoteToken, amount, price, takerFee, makerFee),
+                uint256(0x120),
+                uint256(0x240),
                 abi.encode(
                     takerOrder.tx.sender,
                     takerOrder.tx.amount,
@@ -404,15 +413,65 @@ contract TradeExecutionTest is ExchangeBaseTest {
         );
     }
 
-    function setupWallets() internal {
-        MockERC20 usdcMock = new MockERC20("USD Coin", "USDC", 6);
-        usdcMock.mint(taker, 500000e6);
-        usdcMock.mint(maker, 500000e6);
-        MockERC20 btcMock = new MockERC20("Bitcoin", "BTC", 8);
-        btcMock.mint(taker, 100e8);
-        btcMock.mint(maker, 100e8);
+    function test_BatchFailures() public {
+        setupWallets();
 
-        usdcAddress = address(usdcMock);
-        btcAddress = address(btcMock);
+        // wallet1 - deposit usdc and native token
+        deposit(wallet1, usdcAddress, 1000e6);
+        verifyBalances(wallet1, usdcAddress, 1000e6, 499000e6, 1000e6);
+        deposit(wallet1, 2e18);
+        verifyBalances(wallet1, 2e18, 8e18, 2e18);
+
+        uint64 sequence = 50000;
+
+        bytes memory tx1 =
+            createSignedWithdrawTxWithInvalidSignature(takerPrivateKey, usdcAddress, 200e6, 10000, sequence);
+        bytes memory tx2 = createSignedWithdrawNativeTx(takerPrivateKey, 2e18, 10001, sequence + 1);
+        (IExchange.OrderWithSignature memory takerOrder,) =
+            signOrder(takerPrivateKey, btcAddress, usdcAddress, 3e8, 70000e6, 1);
+        (IExchange.OrderWithSignature memory makerOrder,) =
+            signOrder(makerPrivateKey, btcAddress, usdcAddress, -5e8, 70000e6, 2);
+        bytes memory tx3 =
+            createTradeExecution(btcAddress, address(0), 3e8, 70000e6, 0, 0, takerOrder, makerOrder, sequence + 2);
+
+        bytes[] memory batch1 = new bytes[](3);
+        batch1[0] = tx1;
+        batch1[1] = tx2;
+        batch1[2] = tx3;
+
+        // check that events are emitted for failed transactions and batch hash is not saved on a failure
+        vm.startPrank(submitter);
+        vm.expectEmit(exchangeProxyAddress);
+        emit IExchange.PrepareTransactionFailed(sequence, IExchange.ErrorCode.InvalidSignature);
+        vm.expectEmit(exchangeProxyAddress);
+        emit IExchange.PrepareTransactionFailed(sequence + 2, IExchange.ErrorCode.InsufficientBalance);
+        exchange.prepareBatch(batch1);
+        assertTrue(exchange.batchHash() == 0);
+
+        // since prepare had failures, batch should be rolled back, make sure cannot submit
+        vm.expectRevert(bytes("No batch prepared"));
+        exchange.submitBatch(batch1);
+
+        // remove bad ones and prepare a good batch
+        bytes[] memory batch2 = new bytes[](1);
+        batch2[0] = tx2;
+        exchange.prepareBatch(batch2);
+
+        // check fails if a different batch submitted to what was prepared
+        bytes[] memory batch3 = new bytes[](1);
+        batch3[0] = tx1;
+        vm.expectRevert(bytes("Hash does not match prepared batch"));
+        exchange.submitBatch(batch3);
+
+        // cannot prepare a different batch before current one is committed or rolled back
+        vm.expectRevert(bytes("Batch in progress, submit or rollback"));
+        exchange.prepareBatch(batch2);
+
+        // rollback
+        exchange.rollbackBatch();
+        assertTrue(exchange.batchHash() == 0);
+        exchange.prepareBatch(batch2);
+        assertFalse(exchange.batchHash() == 0);
+        exchange.submitBatch(batch2);
     }
 }


### PR DESCRIPTION
- there is now a prepareBatch, submitBatch and rollbackBatch methods
- when prepareBatch is called, events are emitted for failed Txs in the batch. A sequence is now provided for each tx and the emitted event references that sequence.
- If any events are emitted, the batch is automatically rolled back.
- If there are no errors, then a batch hash is calculated for all txs in the batch and stored,
- The subsequent call to submitTransaction calculated the same hash and it must match what was stored for the prepare. If not submit is rejected.
- rollback batch is not currently needed but will be when we do 2 phase across chains.